### PR TITLE
ユーザー登録のurl修正

### DIFF
--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -4,6 +4,6 @@
   <%= link_to 'ログアウト', logout_path, method: :delete %>
 <% else %>
   <%= link_to 'ログイン', login_path %>
-  <%= link_to 'ユーザー登録', new_user_path %>
+  <%= link_to 'ユーザー登録', signup_path %>
 <% end %>
 <h2><%= link_to 'グループ一覧', groups_path %></h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     end
   end
   get 'signup', to: 'users#new'
+  post 'signup', to: 'users#create'
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
@@ -18,5 +19,6 @@ Rails.application.routes.draw do
   end
 
   get "/groups/:group_id/comments" => redirect("/groups/%{group_id}")
+  get "/users" => redirect("/signup")
   resources :groups_users, only: [:create, :destroy]
 end


### PR DESCRIPTION
・users/newからsignupへと変更
・ユーザー登録失敗時にリロードするとusersパスを読み込んでいたのでsignupパスへリダイレクト