### PR TITLE
グループコメントでのエラー解消

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,9 +10,18 @@ class CommentsController < ApplicationController
       flash[:success] = "コメント投稿しました"
       redirect_to @group
     else
-      @comments = @group.comments.order('created_at DESC').page(params[:page]).per(5)
+      @g_com = @group.comments
+      @comments = @g_com.order('created_at DESC').page(params[:page]).per(5)
       @restaurants = @group.like_rsts.distinct.order(:id).page(params[:page]).per(5)
       @likes_count = Like.group_likes_count(params[:group_id])
+      @com_all = @g_com.count
+
+      if !params[:com]
+        @com_num = @com_all
+      else
+        @com_num = @com_all - (params[:com].to_i - 1) * 5
+      end
+
       flash.now[:danger] = "コメントの投稿に失敗しました"
       render "groups/show"
     end


### PR DESCRIPTION
コメントが空の場合に書き込むを押す、201字以上でコメント書き込んだ場合にエラーが出ていたのを解消。
コメントエラー時のレンダリングで問題が起きたので、
groupsコントローラーで持っていた値をcommentsコントローラーにも値を持たせた。